### PR TITLE
Fixed Incorrect Spelling of "resourcePath" to fix script.

### DIFF
--- a/server/constants.lua
+++ b/server/constants.lua
@@ -5,6 +5,6 @@ constants.resourcePath = GetResourcePath(cache.resource):gsub('//', '/')
 constants.savedMLODir = 'saved_mlos'
 constants.savedMLODirPath = ('%s/%s'):format(constants.resourcePath, constants.savedMLODir)
 constants.generatedFilesDir = 'generated_files'
-constants.generatedFilesDirPath = ('%s/%s'):format(constants.reosurcePath, constants.generatedFilesDir)
+constants.generatedFilesDirPath = ('%s/%s'):format(constants.resourcePath, constants.generatedFilesDir)
 
 return table.freeze(constants)


### PR DESCRIPTION
Solved issue of script unable to save, load or export files due to spelling mistake causing a nil value in the paths.